### PR TITLE
Add configuration for triggering redrawing of markers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   EditorView,
   WidgetType,
   PluginValue,
+  ViewUpdate,
 } from '@codemirror/view';
 import { getIndentUnit } from '@codemirror/language';
 import { Extension, Text, RangeSet, EditorState } from '@codemirror/state';
@@ -324,7 +325,13 @@ function getLinesWithActiveIndentMarker(
   return { start, end, activeIndent: currentIndent };
 }
 
-function indentationMarkerViewPlugin() {
+type IndentationMarkerConfiguration = {
+  shouldUpdate?: (update: ViewUpdate) => boolean;
+};
+
+function indentationMarkerViewPlugin(
+  {shouldUpdate}: IndentationMarkerConfiguration
+) {
   return ViewPlugin.define<PluginValue & { decorations: RangeSet<Decoration> }>(
     (view) => ({
       decorations: addIndentationMarkers(view),
@@ -332,7 +339,8 @@ function indentationMarkerViewPlugin() {
         if (
           update.docChanged ||
           update.viewportChanged ||
-          update.selectionSet
+          update.selectionSet ||
+          (shouldUpdate && shouldUpdate(update))
         ) {
           this.decorations = addIndentationMarkers(update.view);
         }
@@ -369,6 +377,8 @@ const indentationMarkerBaseTheme = EditorView.baseTheme({
   },
 });
 
-export function indentationMarkers(): Extension {
-  return [indentationMarkerViewPlugin(), indentationMarkerBaseTheme];
+export function indentationMarkers(
+  config?: IndentationMarkerConfiguration
+): Extension {
+  return [indentationMarkerViewPlugin({...config}), indentationMarkerBaseTheme];
 }


### PR DESCRIPTION
Copied from upstream PR https://github.com/replit/codemirror-indentation-markers/pull/3

# Why

<!--
 - Describe what prompted you to make the change
 - It should be a good historical record of the motivations and context of the PR
-->
Sometimes an update to the indentation markers can be skipped, based on business logic. For example, if the `indentUnit` facet is updated dynamically then the indentation markers will only update on the next scroll/keypress/resize. 

# What changed
This PR adds a configuration option to the extension, where a `shouldUpdate` hook can be provided to indicate whether the indentation markers should be recalculated, even if there is no state update. 





<!--
 - Describe what changed to a level of detail that someone with little context with your PR could be able to review it.
 - People from the future should also be able to read this and understand what's going on.
 - Annotate changes with a self-review where necessary.
 - Post a screenshot or video when relevant
-->

# Test plan

<!-- 
 - Test plans should allow people without context to run through a list of steps and assert behavior.
 - If this is a bug fix, the test plan should include steps to reproduce the problem.
 - If this is a feature, the test plan should reflect a human-readable end-to-end test.
-->

The following patch sets up a test case where the indentation will update without any state change after 3s.


https://user-images.githubusercontent.com/3295293/201678273-2cd12e4d-ae42-4e42-8e87-5d1292d5bc78.mp4

```diff
--- a/dev/index.ts
+++ b/dev/index.ts
@@ -1,8 +1,9 @@
 import { basicSetup } from 'codemirror';
-import { EditorView, keymap } from '@codemirror/view';
-import { EditorState } from '@codemirror/state';
+import { EditorView, keymap, ViewPlugin } from '@codemirror/view';
+import { EditorState, StateEffect } from '@codemirror/state';
 import { indentWithTab } from '@codemirror/commands';
 import { indentationMarkers } from '../src';
+import { indentUnit } from '@codemirror/language';
 
 const doc = `
 def read_file(path):
@@ -29,7 +30,17 @@ new EditorView({
     extensions: [
       basicSetup,
       keymap.of([indentWithTab]),
-      indentationMarkers()
+      indentationMarkers({ shouldUpdate: (update) => true }),
+      ViewPlugin.define((view) => {
+        setTimeout(() => {
+          view.dispatch({
+            effects: StateEffect.appendConfig.of({
+              extension: indentUnit.of(" "),
+            }),
+          });
+        }, 3000);
+        return {};
+      }),
     ],
   }),
   parent: document.querySelector('#editor'),
```
